### PR TITLE
Clear user suggestion field for ScheduledTaskEditor

### DIFF
--- a/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
+++ b/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
@@ -220,7 +220,7 @@ public class ScheduledTaskEditor<T extends Entity & UserDetails> extends Abstrac
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     private void initUserNameField() {
-        userNameField.setOptionStyleProvider(UserDetails::getUsername);
+        userNameField.setOptionStyleProvider(item -> item.getUsername());
         userNameField.addValueChangeListener(e -> taskDs.getItem().setUserName(e.getValue() == null ? null : e.getValue().getUsername()));
         userNameField.setSearchExecutor((searchString, searchParams) -> new ArrayList(userRepository.getByUsernameLike(searchString)));
     }

--- a/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
+++ b/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
@@ -16,7 +16,6 @@
 
 package com.haulmont.cuba.web.app.scheduled;
 
-import com.google.common.base.Strings;
 import com.haulmont.cuba.core.app.SchedulingService;
 import com.haulmont.cuba.core.app.scheduled.MethodInfo;
 import com.haulmont.cuba.core.app.scheduled.MethodParameterInfo;
@@ -26,7 +25,7 @@ import com.haulmont.cuba.core.entity.SchedulingType;
 import com.haulmont.cuba.gui.UiComponents;
 import com.haulmont.cuba.gui.components.*;
 import com.haulmont.cuba.gui.data.Datasource;
-import com.haulmont.cuba.web.gui.components.WebSuggestionField;
+import com.haulmont.cuba.web.gui.components.WebSuggestionPickerField;
 import io.jmix.core.Entity;
 import io.jmix.core.security.UserRepository;
 import io.jmix.ui.component.ComponentContainer;
@@ -38,7 +37,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import javax.inject.Inject;
 import java.util.*;
 
-public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
+public class ScheduledTaskEditor<T extends Entity & UserDetails> extends AbstractEditor<ScheduledTask> {
 
     @Inject
     protected LookupField<String> beanNameField;
@@ -47,7 +46,7 @@ public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
     protected LookupField<MethodInfo> methodNameField;
 
     @Inject
-    protected WebSuggestionField<UserDetails> userNameField;
+    protected WebSuggestionPickerField<T> userNameField;
 
     @Inject
     protected UserRepository userRepository;
@@ -219,15 +218,11 @@ public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
         });
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void initUserNameField() {
         userNameField.setOptionStyleProvider(UserDetails::getUsername);
         userNameField.addValueChangeListener(e -> taskDs.getItem().setUserName(e.getValue() == null ? null : e.getValue().getUsername()));
-        userNameField.setSearchExecutor((searchString, searchParams) -> new ArrayList<>(userRepository.getByUsernameLike(searchString)));
-        userNameField.setEnterPressHandler(enterPressEvent -> {
-            if (Strings.isNullOrEmpty(enterPressEvent.getText())) {
-                userNameField.clear();
-            }
-        });
+        userNameField.setSearchExecutor((searchString, searchParams) -> new ArrayList(userRepository.getByUsernameLike(searchString)));
     }
 
     protected void setSchedulingTypeField(SchedulingType value) {
@@ -249,6 +244,7 @@ public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void setItem(Entity item) {
         super.setItem(item);
 
@@ -256,7 +252,7 @@ public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
             setInitialMethodNameValue(getItem());
         }
         if (StringUtils.isNotEmpty(getItem().getUserName())) {
-            userNameField.setValue(userRepository.loadUserByUsername(getItem().getUserName()));
+            userNameField.setValue((T) userRepository.loadUserByUsername(getItem().getUserName()));
         }
     }
 

--- a/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
+++ b/cuba/src/main/java/com/haulmont/cuba/web/app/scheduled/ScheduledTaskEditor.java
@@ -16,6 +16,7 @@
 
 package com.haulmont.cuba.web.app.scheduled;
 
+import com.google.common.base.Strings;
 import com.haulmont.cuba.core.app.SchedulingService;
 import com.haulmont.cuba.core.app.scheduled.MethodInfo;
 import com.haulmont.cuba.core.app.scheduled.MethodParameterInfo;
@@ -220,8 +221,13 @@ public class ScheduledTaskEditor extends AbstractEditor<ScheduledTask> {
 
     private void initUserNameField() {
         userNameField.setOptionStyleProvider(UserDetails::getUsername);
-        userNameField.addValueChangeListener(e -> taskDs.getItem().setUserName(e.getValue().getUsername()));
+        userNameField.addValueChangeListener(e -> taskDs.getItem().setUserName(e.getValue() == null ? null : e.getValue().getUsername()));
         userNameField.setSearchExecutor((searchString, searchParams) -> new ArrayList<>(userRepository.getByUsernameLike(searchString)));
+        userNameField.setEnterPressHandler(enterPressEvent -> {
+            if (Strings.isNullOrEmpty(enterPressEvent.getText())) {
+                userNameField.clear();
+            }
+        });
     }
 
     protected void setSchedulingTypeField(SchedulingType value) {

--- a/cuba/src/main/resources/com/haulmont/cuba/web/app/scheduled/scheduled-task-edit.xml
+++ b/cuba/src/main/resources/com/haulmont/cuba/web/app/scheduled/scheduled-task-edit.xml
@@ -142,8 +142,12 @@
                         <row>
                             <label value="msg://com.haulmont.cuba.core.entity/ScheduledTask.userName"
                                    align="MIDDLE_LEFT"/>
-                            <suggestionField id="userNameField" minSearchStringLength="1"
-                                             width="${fieldWidth}"/>
+                            <suggestionPickerField id="userNameField" minSearchStringLength="1"
+                                                   width="${fieldWidth}">
+                                <actions>
+                                    <action id="clear" type="picker_clear"/>
+                                </actions>
+                            </suggestionPickerField>
                         </row>
                         <row>
                             <label value="msg://com.haulmont.cuba.core.entity/ScheduledTask.singleton"


### PR DESCRIPTION
Added handler for enterPressEvent, which will clear userSuggestionField in case of input text is empty 